### PR TITLE
Remove create resource

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -43,8 +43,8 @@ authentication_provider_instances:
     attributes:         'DigestReplayDetectionEnabled;UseDefaultUserNameMapper;DefaultUserNameMapperAttributeType;ActiveTypes'
     attributesvalues:   '1;1;CN;AuthenticatedUser::X.509'
 
-adminserver_address:        &adminserver_address        "172.22.5.5"
-node1_address:              &node1_address              "172.22.5.10"
+adminserver_address:        &adminserver_address        "centos6a.lfg.puppetlabs.demo"
+node1_address:              &node1_address              "10.20.1.22"
 node2_address:              &node2_address              "172.22.5.11"
 
 domain_adminserver_address: &domain_adminserver_address "%{hiera('adminserver_address')}"
@@ -56,7 +56,7 @@ hosts:
   'localhost':
     ip:                "127.0.0.1"
     host_aliases:      'localhost.localdomain,localhost4,localhost4.localdomain4'
-  'admin.puppetlabs.vm':
+  'centos6a.lfg.puppetlabs.demo':
     ip:                *domain_adminserver_address
     host_aliases:      'admin'
   'node1.puppetlabs.vm':

--- a/hieradata/node/centos6a.lfg.puppetlabs.demo.yaml
+++ b/hieradata/node/centos6a.lfg.puppetlabs.demo.yaml
@@ -1,5 +1,5 @@
 ---
-
+# centos6a / admin node
 logoutput:                &logoutput                true
 orawls::weblogic::log_output:   *logoutput
 
@@ -76,7 +76,7 @@ wls_setting_instances:
   'default':
     user:               *wls_os_user
     weblogic_home_dir:  *wls_weblogic_home_dir
-    connect_url:        "t3://%{::ipaddress_eth1}:7001"
+    connect_url:        "t3://%{::fqdn}:7001"
     weblogic_user:      *wls_weblogic_user
     weblogic_password:  *domain_wls_password
 #  'D02N02O02Setting':

--- a/manifests/weblogic/base.pp
+++ b/manifests/weblogic/base.pp
@@ -2,6 +2,7 @@ class profile::weblogic::base (
   $wls_os_user           = hiera('wls_os_user', 'webadmin'),
   $wls_os_group          = hiera('wls_os_group', 'webadmns'),
   $wls_domain            = $::wls_domain,
+	$wls_domain_path       = hiera('dft_wls_domains_path'),
   $weblogic_home_dir     = hiera('wls_weblogic_home_dir', '/opt/was/oracle//middleware/wlserver_10.3/'),
   $middleware_home_dir   = hiera('wls_middleware_home_dir', '/opt/was/oracle/middleware'),  
   $oracle_base_home_dir  = hiera('wls_oracle_base_home_dir', '/opt/was/oracle'), 
@@ -22,6 +23,15 @@ class profile::weblogic::base (
     os_group             => "$wls_os_group",
     download_dir         => "$download_dir",
     source               => "$source",
+  }
+  
+  class { 'orautils':
+    osMdwHomeParam    => hiera('wls_middleware_home_dir'),
+    osWlHomeParam     => hiera('wls_weblogic_home_dir'),
+    oraUserParam      => $wls_os_user,
+    oraGroupParam     => $wls_os_group,
+    osDomainParam     => $wls_domain,
+    osDomainPathParam => "${wls_domains_path}/${wls_domain}",
   }
 
   contain profile::weblogic::java

--- a/manifests/weblogic/base.pp
+++ b/manifests/weblogic/base.pp
@@ -76,17 +76,49 @@ class profile::weblogic::base (
     osDomainPathParam => "${domains_dir}/${wls_domain}",
   }
 #
-  class { '::weblogic::services::opatch':
-    default_params   => $default,
-    opatch_instances => $opatch, 
+#  class { '::weblogic::services::opatch':
+#    default_params   => $default,
+#    opatch_instances => $opatch, 
+#  }
+
+# We don't have opatch_instances in yaml, so no need to declar
+#weblogic::opatch { 
+#}
+
+
+#  class { '::weblogic::services::fmw':
+#    default_params => $default,
+#    fmw_installations => $fmw_plugins,
+#  }   
+
+  weblogic::fmw { 'soaPS7':
+     fmw_product => "soa",
+     fmw_file1   => "ofm_soa_generic_11.1.1.7.0_disk1_1of2.zip",
+     fmw_file2   => "ofm_soa_generic_11.1.1.7.0_disk1_2of2.zip",
+     log_output  => true,
+     remote_file => false,
   }
-#
-  class { '::weblogic::services::fmw':
-    default_params => $default,
-    fmw_installations => $fmw_plugins,
-  }   
-#
-#
+  weblogic::fmw { 'webTierPS7':
+     fmw_product => "web",
+     fmw_file1   => "ofm_webtier_linux_11.1.1.7.0_64_disk1_1of1.zip",
+     log_output  => true,
+     remote_file => false,
+   }
+  weblogic::fmw { 'osbPS7':
+     fmw_product => "osb",
+     fmw_file1   => "ofm_osb_generic_11.1.1.7.0_disk1_1of1.zip",
+     log_output  => true,
+     remote_file => false,
+   }
+  weblogic::fmw { 'oudPS5':
+     fmw_product => 'oud',
+     fmw_file1   => 'ofm_oud_generic_11.1.1.5.0_disk1_1of1.zip',
+     log_output  => true,
+     remote_file => false,
+  }
+
+
+
   Class['profile::weblogic::java'] ->
   Class['weblogic::utils::user'] ->
   Class['weblogic::os'] ->

--- a/manifests/weblogic/base.pp
+++ b/manifests/weblogic/base.pp
@@ -26,27 +26,27 @@ class profile::weblogic::base (
 
   contain profile::weblogic::java
 
-  class { 'weblogic::utils::user':
+  class { '::weblogic::utils::user':
     user_name     => $wls_os_user,
     user_group    => $wls_os_group,
     user_home     => "/home/$wls_os_user",
     user_password => '$1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0',
   }
 
-  class { 'weblogic::os':
+  class { '::weblogic::os':
     host_instances => {},
     install_jdk    => false,
     java_homes     => '/usr/java/latest',
   }
 
-  class { 'weblogic::urandomfix': }
+  class { '::weblogic::urandomfix': }
 
-  class { 'weblogic::ssh':
+  class { '::weblogic::ssh':
     os_user  => "$wls_os_user",
     os_group => "$wls_os_group",
   }
   
-  class { 'weblogic::provision': 
+  class { '::weblogic::provision': 
     version               =>  '1036',
     filename              =>  'wls1036_generic.jar',
     export_dir            =>  '/tmp/oracle',
@@ -56,12 +56,12 @@ class profile::weblogic::base (
     
   include weblogic::services::bsu
 
-  class { 'weblogic::services::fmw':
+  class { '::weblogic::services::fmw':
     default_params => $default,
     fmw_installations => $fmw_plugins,
   }   
 
-  class { 'weblogic::services::opatch':
+  class { '::weblogic::services::opatch':
     default_params   => $default,
     opatch_instances => $opatch, 
   }

--- a/manifests/weblogic/domainadmin.pp
+++ b/manifests/weblogic/domainadmin.pp
@@ -1,4 +1,14 @@
-class profile::weblogic::domainadmin {
+class profile::weblogic::domainadmin (
+	$version = '1036',
+	$middleware_home,
+	$weblogic_home,
+	$domains_defaults = {},
+	$nodemanager_defaults = {},
+	$startwls_defaults = {},
+	$userconfig_defaults = {},
+	$security_defaults = {},
+	$basic_config_defaults = {},
+) {
   $wls_os_user = hiera('wls_os_user')
   $wls_os_group = hiera('wls_os_group')
   $wls_domain = $::wls_domain
@@ -13,13 +23,55 @@ class profile::weblogic::domainadmin {
     osDomainPathParam => "${wls_domains_path}/${wls_domain}",
   }
 
-  include weblogic::services::domains
-  include weblogic::services::nodemanager
-  include weblogic::services::startwls
-  include weblogic::services::userconfig
+  class { '::weblogic::services::domains':
+    default_params        => $domains_defaults,
+    file_domain_libs      => hiera('file_domain_libs', {}),
+    domain_instances      => hiera('domain_instances', {}),
+    wls_setting_instances => hiera('wls_setting_instances', {}),
+  }
 
-  include weblogic::services::security
-  include weblogic::services::basic_config
+  class { '::weblogic::services::nodemanager': 
+    default_params                => $nodemanager_defaults,
+    nodemanager_instances         => hiera('nodemanager_instances', {}),
+    version                       => hiera('wls_version'),
+    wls_weblogic_home_dir         => hiera('wls_weblogic_home_dir'),
+    wls_os_user                   => hiera('wls_os_user'),
+    wls_jsse_enabled              => hiera('wls_jsse_enabled', false),
+    wls_custom_trust              => hiera('wls_custom_trust', false),
+    wls_trust_keystore_file       => hiera('wls_trust_keystore_file', undef),
+    wls_trust_keystore_passphrase => hiera('wls_trust_keystore_passphrase', undef),
+  }
+
+  class { '::weblogic::services::startwls':
+    default_params    => $startwls_defaults,
+    control_instances => hiera('control_instances', {}),
+  }
+  
+  class { '::weblogic::services::userconfig':
+    default_params       => $userconfig_defaults,
+    userconfig_instances => hiera('userconfig_instances', {}),
+  }
+
+  class { '::weblogic::services::security':
+    default_params                    => $security_defaults,
+    user_instances                    => hiera('user_instances', {}),
+    group_instances                   => hiera('group_instances', {}),
+    authentication_provider_instances => hiera('authentication_provider_instances', {}),
+  }
+
+  class { '::weblogic::services::basic_config':
+    default_params                   => $basic_config_defaults,
+    wls_domain_instances             => hiera('wls_domain_instances', {}),
+    wls_adminserver_instances_domain => hiera('wls_adminserver_instances_domain', {}),
+    machines_instances               => hiera('machines_instances', {}),
+    server_instances                 => hiera('server_instances'),
+    wls_adminserver_instances_server => hiera('wls_adminserver_instances_server', {}),
+    server_channel_instances         => hiera('server_channel_instances', {}),
+    cluster_instances                => hiera('cluster_instances', {}),
+    coherence_cluster_instances      => hiera('coherence_cluster_instances', {}),
+    server_template_instances        => hiera('server_template_instances', {}),
+    mail_session_instances           => hiera('mail_session_instances', {}),
+  }
 
   Class['orautils'] ->
   Class['weblogic::services::domains'] ->

--- a/manifests/weblogic/domainadmin.pp
+++ b/manifests/weblogic/domainadmin.pp
@@ -1,7 +1,30 @@
 class profile::weblogic::domainadmin (
-	$version = '1036',
-	$middleware_home,
-	$weblogic_home,
+	$version = hiera('wls_version'),
+	$nodemanager_instances = hiera('nodemanager_instances', {}),
+	$middleware_home = hiera('wls_middleware_home_dir'),
+	$weblogic_home = hiera('wls_weblogic_home_dir'),
+	$os_user = hiera('wls_os_user'),
+	$os_group = hiera('wls_os_group'),
+	$wls_domain = $::wls_domain,
+	$wls_domain_path = hiera('dft_wls_domains_path'),
+	$jsse_enabled = hiera('wls_jsse_enabled', false),
+	$custom_trust = hiera('wls_custom_trust', false),
+	$trust_keystore_file = hiera('wls_trust_keystore_file', undef),
+	$trust_keystore_passphrase = hiera('wls_trust_keystore_file', undef),
+	$userconfig_instances = hiera('userconfig_instances', {}),
+	$user_instances = hiera('user_instances', {}),
+	$group_instances = hiera('group_instances', {}),
+	$authentication_provider_instances = hiera('authentication_provider_instances', {}),
+	$wls_domain_instances = hiera('wls_domain_instances', {}),
+	$wls_adminserver_instances_domain = hiera('wls_adminserver_instances_domain', {}),
+	$machines_instances = hiera('machines_instances', {}),
+	$server_instances = hiera('server_instances'),
+	$wls_adminserver_instances_server = hiera('wls_adminserver_instances_server', {}),
+	$server_channel_instances = hiera('server_channel_instances', {}),
+	$cluster_instances = hiera('cluster_instances', {}),
+	$coherence_cluster_instances = hiera('coherence_cluster_instances', {}),
+	$server_template_instances = hiera('server_template_instances', {}),
+	$mail_session_instances = hiera('mail_session_instances', {}),
 	$domains_defaults = {},
 	$nodemanager_defaults = {},
 	$startwls_defaults = {},
@@ -9,16 +32,12 @@ class profile::weblogic::domainadmin (
 	$security_defaults = {},
 	$basic_config_defaults = {},
 ) {
-  $wls_os_user = hiera('wls_os_user')
-  $wls_os_group = hiera('wls_os_group')
-  $wls_domain = $::wls_domain
-  $wsl_domain_path = hiera('dft_wls_domains_path')
 
   class { 'orautils':
     osMdwHomeParam    => hiera('wls_middleware_home_dir'),
     osWlHomeParam     => hiera('wls_weblogic_home_dir'),
-    oraUserParam      => $wls_os_user,
-    oraGroupParam     => $wls_os_group,
+    oraUserParam      => $os_user,
+    oraGroupParam     => $os_group,
     osDomainParam     => $wls_domain,
     osDomainPathParam => "${wls_domains_path}/${wls_domain}",
   }
@@ -32,14 +51,14 @@ class profile::weblogic::domainadmin (
 
   class { '::weblogic::services::nodemanager': 
     default_params                => $nodemanager_defaults,
-    nodemanager_instances         => hiera('nodemanager_instances', {}),
-    version                       => hiera('wls_version'),
-    wls_weblogic_home_dir         => hiera('wls_weblogic_home_dir'),
-    wls_os_user                   => hiera('wls_os_user'),
-    wls_jsse_enabled              => hiera('wls_jsse_enabled', false),
-    wls_custom_trust              => hiera('wls_custom_trust', false),
-    wls_trust_keystore_file       => hiera('wls_trust_keystore_file', undef),
-    wls_trust_keystore_passphrase => hiera('wls_trust_keystore_passphrase', undef),
+    nodemanager_instances         => $nodemanager_instances,
+    version                       => $version,
+    wls_weblogic_home_dir         => $weblogic_home,
+    wls_os_user                   => $os_user,
+    wls_jsse_enabled              => $jsse_enabled,
+    wls_custom_trust              => $custom_trust,
+    wls_trust_keystore_file       => $trust_keystore_file,
+    wls_trust_keystore_passphrase => $trust_keystore_passphrase,
   }
 
   class { '::weblogic::services::startwls':
@@ -49,28 +68,28 @@ class profile::weblogic::domainadmin (
   
   class { '::weblogic::services::userconfig':
     default_params       => $userconfig_defaults,
-    userconfig_instances => hiera('userconfig_instances', {}),
+    userconfig_instances => $userconfig_instances,
   }
 
   class { '::weblogic::services::security':
     default_params                    => $security_defaults,
-    user_instances                    => hiera('user_instances', {}),
-    group_instances                   => hiera('group_instances', {}),
-    authentication_provider_instances => hiera('authentication_provider_instances', {}),
+    user_instances                    => $user_instances,
+    group_instances                   => $group_instances,
+    authentication_provider_instances => $authentication_provider_instances,
   }
 
   class { '::weblogic::services::basic_config':
     default_params                   => $basic_config_defaults,
-    wls_domain_instances             => hiera('wls_domain_instances', {}),
-    wls_adminserver_instances_domain => hiera('wls_adminserver_instances_domain', {}),
-    machines_instances               => hiera('machines_instances', {}),
-    server_instances                 => hiera('server_instances'),
-    wls_adminserver_instances_server => hiera('wls_adminserver_instances_server', {}),
-    server_channel_instances         => hiera('server_channel_instances', {}),
-    cluster_instances                => hiera('cluster_instances', {}),
-    coherence_cluster_instances      => hiera('coherence_cluster_instances', {}),
-    server_template_instances        => hiera('server_template_instances', {}),
-    mail_session_instances           => hiera('mail_session_instances', {}),
+    wls_domain_instances             => $wls_domain_instances,
+    wls_adminserver_instances_domain => $wls_adminserver_instances_domain,
+    machines_instances               => $machines_instances,
+    server_instances                 => $server_instances,
+    wls_adminserver_instances_server => $wls_adminserver_instances_server,
+    server_channel_instances         => $server_channel_instances,
+    cluster_instances                => $cluster_instances,
+    coherence_cluster_instances      => $coherence_cluster_instances,
+    server_template_instances        => $server_template_instances,
+    mail_session_instances           => $mail_session_instances,
   }
 
   Class['orautils'] ->

--- a/manifests/weblogic/domainadmin.pp
+++ b/manifests/weblogic/domainadmin.pp
@@ -33,14 +33,6 @@ class profile::weblogic::domainadmin (
 	$basic_config_defaults = {},
 ) {
 
-  class { 'orautils':
-    osMdwHomeParam    => hiera('wls_middleware_home_dir'),
-    osWlHomeParam     => hiera('wls_weblogic_home_dir'),
-    oraUserParam      => $os_user,
-    oraGroupParam     => $os_group,
-    osDomainParam     => $wls_domain,
-    osDomainPathParam => "${wls_domains_path}/${wls_domain}",
-  }
 
   class { '::weblogic::services::domains':
     default_params        => $domains_defaults,


### PR DESCRIPTION
This is a redo of the base and domainadmin.pp files to stop using the create_resources calls entirely and just specifically call out the code. It means we stop using yaml as a way to write puppet code and removes a layer of abstraction: yaml is for data, not configuration.

Things that need to be checked:
params and ordering - the class declarations at the bottom of each manifest need to be updated to reflect this, we can probably just put the sane defaults for these outside of hiera and in the parameter declarations at the top of the class.

This is also easier to troubleshoot now.
